### PR TITLE
feat: update to import viem/chains import of hederaTestnet

### DIFF
--- a/connect-viem/connect.js
+++ b/connect-viem/connect.js
@@ -1,4 +1,5 @@
-import { createPublicClient, http, defineChain } from 'viem';
+import { createPublicClient, http } from 'viem';
+import { hederaTestnet } from 'viem/chains';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -15,41 +16,22 @@ if (!rpcUrlHederatestnet || !rpcUrlHederatestnet.startsWith('http')) {
     'Missing or invalid value in RPC_URL env var',
   );
 }
-
-const hederaTestnetChain = defineChain({
-    id: 0x128,
-    name: 'HederaTestnet',
-    nativeCurrency: {
-        symbol: 'ℏ',
-        name: 'HBAR',
-        decimals:  18,
-    },
-    rpcUrls: {
-        default: {
-            http: [rpcUrlHederatestnet],
-        },
-    },
-    blockExplorers: {
-        default: {
-            name: 'Hashscan',
-            url: 'https://hashscan.io/testnet'
-        },
-    },
-    contracts: {},
-});
  
 const web3Client = createPublicClient({
-  chain: hederaTestnetChain,
-  transport: http(),
+  chain: hederaTestnet,
+  transport: http(rpcUrlHederatestnet, {
+    batch: false,
+  }),
 });
 
 async function main() {
-    const blockNumber = await web3Client.getBlockNumber();
+    const [blockNumber, balance] = await Promise.all([
+        web3Client.getBlockNumber(),
+        web3Client.getBalance({
+            address: '0x7394111093687e9710b7a7aeba3ba0f417c54474',
+        }),
+    ]);
     console.log('block number', blockNumber);
-
-    const balance = await web3Client.getBalance({
-        address: '0x7394111093687e9710b7a7aeba3ba0f417c54474',
-    });
     console.log('balance', balance);
 }
 

--- a/connect-viem/package.json
+++ b/connect-viem/package.json
@@ -2,6 +2,6 @@
     "type": "module",
     "dependencies": {
         "dotenv": "16.4.1",
-        "viem": "2.7.1"
+        "viem": "2.7.3"
     }
 }

--- a/dapp-viem/README.md
+++ b/dapp-viem/README.md
@@ -26,8 +26,8 @@ Then visit `http://127.0.0.1:8111/` in your browser.
 
 The `dapp.ts` file in this directory contains all the application code.
 
-A network config for `hederaTestnetChain` is defined manually here.
-Change the value of `rpcUrls.default.http` to match what you have configured in Metamask.
+A network config for `hederaTestnet` is imported from `viem/chains`.
+The RPC URL is obtained from what you've configured in Metamask.
 
 Subsequently `web3Client` obejct is created,
 which is a combination of `viem.walletClient` and `viem.publicClient`.

--- a/dapp-viem/package.json
+++ b/dapp-viem/package.json
@@ -7,6 +7,6 @@
         "serve": "npx http-server@14.1.1 ./dist -c-1 -p 8111"
     },
     "dependencies": {
-        "viem": "2.7.1"
+        "viem": "2.7.3"
     }
 }

--- a/dapp-viem/src/dapp.ts
+++ b/dapp-viem/src/dapp.ts
@@ -5,7 +5,11 @@ import {
     type Address,
     type SendTransactionErrorType,
 } from 'viem';
-import { hederaTestnet } from 'viem/chains';
+import {
+    hedera as hederaMainnet,
+    hederaTestnet,
+    hederaPreviewnet,
+} from 'viem/chains';
 
 // NOTE this declare is done to avoid the TS type check error
 // for `window.ethereum` not being present.
@@ -55,6 +59,22 @@ async function main() {
 
     const transferAmountInput = document.querySelector('#transferAmount') as HTMLInputElement;
     const transferToInput = document.querySelector('#transferTo') as HTMLInputElement;
+
+    document.querySelector('#addChainMainnet')?.addEventListener('click', async function () {
+        web3Client.addChain({
+            chain: hederaMainnet,
+        });
+    });
+    document.querySelector('#addChainTestnet')?.addEventListener('click', async function () {
+        web3Client.addChain({
+            chain: hederaTestnet,
+        });
+    });
+    document.querySelector('#addChainPreviewnet')?.addEventListener('click', async function () {
+        web3Client.addChain({
+            chain: hederaPreviewnet,
+        });
+    });
 
     document.querySelector('#transferExecute')?.addEventListener('click', async function() {
         // NOTE allow up to 10 significant figures (out of 18) when converting to `uint256`

--- a/dapp-viem/src/dapp.ts
+++ b/dapp-viem/src/dapp.ts
@@ -1,43 +1,19 @@
 import {
-    defineChain,
     createWalletClient,
     custom,
     publicActions,
     type Address,
     type SendTransactionErrorType,
 } from 'viem';
+import { hederaTestnet } from 'viem/chains';
 
-// NOTE this is done to avoid the TS type check error for `window.ethereum` not being present.
+// NOTE this declare is done to avoid the TS type check error
+// for `window.ethereum` not being present.
 declare global {
     interface Window {
       ethereum?: any;
     }
 }
-
-// NOTE When this PR is merged, can import `hederaTestnet` from `viem/chains` directly instead
-// Ref: https://github.com/wevm/viem/pull/1758
-const hederaTestnetChain = defineChain({
-    id: 0x128,
-    name: 'HederaTestnet',
-    nativeCurrency: {
-        symbol: 'ℏ',
-        name: 'HBAR',
-        decimals:  18,
-    },
-    rpcUrls: {
-        default: {
-            http: ['http://localhost:7546'],
-        },
-    },
-    blockExplorers: {
-        default: {
-            name: 'Hashscan',
-            url: 'https://hashscan.io/testnet'
-        },
-    },
-    contracts: {},
-});
-
 let injectedWeb3;
 if (!window.ethereum) {
     throw new Error('No injected web3 instance found (window.ethereum).');
@@ -45,9 +21,12 @@ if (!window.ethereum) {
     injectedWeb3 = window.ethereum;
 }
 
+// NOTE that RPC URL used will be the one set in the ibjected web3 provider (e.g. Metamask)
 const web3Client = createWalletClient({
-  chain: hederaTestnetChain,
-  transport: custom(injectedWeb3),
+  chain: hederaTestnet,
+  transport: custom(injectedWeb3, {
+    retryDelay: 1000,
+  }),
 }).extend(publicActions);
 
 async function main() {
@@ -62,15 +41,16 @@ async function main() {
         throw new Error('request addresses returned none');
     }
 
-    const balance = await web3Client.getBalance({
-        address: addresses[0],
-    });
+    const [balance, nonce] = await Promise.all([
+        web3Client.getBalance({
+            address: addresses[0],
+        }),
+        web3Client.getTransactionCount({
+            address: addresses[0],
+            blockTag: 'pending',
+        })
+    ]);
     console.log('balance', balance);
-
-    const nonce = await web3Client.getTransactionCount({
-        address: addresses[0],
-        blockTag: 'pending',
-    });
     console.log('nonce', nonce);
 
     const transferAmountInput = document.querySelector('#transferAmount') as HTMLInputElement;
@@ -101,4 +81,3 @@ async function main() {
 }
 
 main();
-

--- a/dapp-viem/static/index.html
+++ b/dapp-viem/static/index.html
@@ -9,6 +9,14 @@
   <body>
     <h1>Viem + Hedera Demo DApp</h1>
     <div id="dapp">
+      <div id="addChain">
+        <button id="addChainMainnet">Add Hedera Mainnet</button>
+        <br />
+        <button id="addChainTestnet">Add Hedera Testnet</button>
+        <br />
+        <button id="addChainPreviewnet">Add Hedera Previewnet</button>
+      </div>
+      <hr />
       <div id="transfer">
         <label for="transferAmount" title="in HBAR">amount:</label>
         <br />


### PR DESCRIPTION
## What

- remove manual definition of `hederaTestnet`, and use the one imported from `viem/chains` instead
  - update `connect-viem` and update `dapp-viem`
- add network buttons for all 3 hedera public networks
  - update `dapp-viem`

## Why

- `hedera`, `hederaTestnet`, and `hederaPreviewnet` are newly available on `viem@2.7.3`

## Refs

- PR that added this: https://github.com/wevm/viem/pull/1758
- Tweet: https://twitter.com/bguiz/status/1754322786951299128