### PR TITLE
Code Example (part3) ERC721 Upgradeable UUPS Proxy Pattern

### DIFF
--- a/hardhat-erc-721-mint-burn/README.md
+++ b/hardhat-erc-721-mint-burn/README.md
@@ -9,6 +9,7 @@
 1. [Setup](#setup)
 2. [Tutorial Part 1: Deploy an ERC-721 contract - Mint and Burn a token](#tutorial-part-1-deploy-an-erc-721-contract---mint-and-burn-a-token)
 3. [Tutorial Part 2: Access Control, Token URI, pause, and transfer](#tutorial-part-2-access-control-token-uri-pause-and-transfer)
+4. [Tutorial Part 3: UUPS Upgradeable Proxy Pattern](#tutorial-part-3-uups-upgradeable-proxy-pattern)
 
 # Setup
 
@@ -90,3 +91,28 @@ npx hardhat run scripts/transfer-advanced.js --network testnet
 ```
 
 That's it! You have deployed an ERC-721 contract with access control, token URI, pause, and transfer functionality.
+
+# Tutorial Part 3: UUPS Upgradeable Proxy Pattern
+
+### 1. Recompile the contract:
+
+```bash
+npx hardhat compile
+```
+
+### 2. Run the "deploy-upgradeable.js" script:
+
+This script deploys the contract using the UUPS upgradeable proxy pattern. Make sure to copy the contract address, you'll need it for the next step.
+
+```bash
+npx hardhat run scripts/deploy-upgradeable.js --network testnet
+```
+
+### 3. Upgrade the contract and verify it
+
+This script upgrades the contract to a new version. Make sure to replace the contract address in the script with the one you copied from the previous step. Once the upgrade is complete, the script calls the `version()` function to verify the upgrade.
+
+```bash
+npx hardhat run scripts/upgrade.js --network testnet
+```
+

--- a/hardhat-erc-721-mint-burn/contracts/erc-721-upgrade-v2.sol
+++ b/hardhat-erc-721-mint-burn/contracts/erc-721-upgrade-v2.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import "./erc-721-upgrade.sol";
+
+contract MyTokenUpgradeableV2 is MyTokenUpgradeable {
+
+    // New function for demonstration
+    function version() public pure returns (string memory) {
+        return "v2";
+    }
+}

--- a/hardhat-erc-721-mint-burn/contracts/erc-721-upgrade.sol
+++ b/hardhat-erc-721-mint-burn/contracts/erc-721-upgrade.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Compatible with OpenZeppelin Contracts ^5.0.0
+pragma solidity ^0.8.22;
+
+import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+contract MyTokenUpgradeable is Initializable, ERC721Upgradeable, OwnableUpgradeable {
+    uint256 private _nextTokenId;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address initialOwner) public initializer {
+        __ERC721_init("MyTokenUpgradeable", "MTU");
+        __Ownable_init(initialOwner);
+    }
+
+    function safeMint(address to) public onlyOwner returns (uint256) {
+        uint256 tokenId = _nextTokenId++;
+        _safeMint(to, tokenId);
+        return tokenId;
+    }
+}

--- a/hardhat-erc-721-mint-burn/hardhat.config.js
+++ b/hardhat-erc-721-mint-burn/hardhat.config.js
@@ -3,7 +3,7 @@ require("@nomicfoundation/hardhat-toolbox");
 
 module.exports = {
   solidity: {
-    version: "0.8.22",
+    version: "^0.8.22",
     settings: {
       optimizer: {
         enabled: true,

--- a/hardhat-erc-721-mint-burn/package.json
+++ b/hardhat-erc-721-mint-burn/package.json
@@ -4,6 +4,8 @@
   "main": "index.js",
   "dependencies": {
     "@openzeppelin/contracts": "^5.2.0",
+    "@openzeppelin/contracts-upgradeable": "^5.3.0",
+    "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "dotenv": "^16.4.7"
   },
   "devDependencies": {

--- a/hardhat-erc-721-mint-burn/scripts/deploy-upgradeable.js
+++ b/hardhat-erc-721-mint-burn/scripts/deploy-upgradeable.js
@@ -1,0 +1,13 @@
+const { ethers, upgrades } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  const Token = await ethers.getContractFactory("MyTokenUpgradeable");
+  const token = await upgrades.deployProxy(Token, [deployer.address], { initializer: "initialize" });
+  await token.waitForDeployment();
+
+  console.log("Upgradeable ERC721 deployed to:", await token.getAddress());
+}
+
+main().catch(console.error);

--- a/hardhat-erc-721-mint-burn/scripts/upgrade.js
+++ b/hardhat-erc-721-mint-burn/scripts/upgrade.js
@@ -1,0 +1,31 @@
+const { ethers, upgrades } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  console.log("Upgrading contract with the account:", deployer.address);
+
+  const MyTokenUpgradeableV2 = await ethers.getContractFactory(
+    "MyTokenUpgradeableV2"
+  );
+
+  // REPLACE with your deployed proxy contract address
+  const proxyAddress = "0xb54c97235A7a90004fEb89dDccd68f36066fea8c";
+
+  const upgraded = await upgrades.upgradeProxy(
+    proxyAddress,
+    MyTokenUpgradeableV2
+  );
+  await upgraded.waitForDeployment();
+
+  console.log(
+    "Contract successfully upgraded at:",
+    await upgraded.getAddress()
+  );
+
+  // Verify the upgrade by calling the new version() function
+  const contractVersion = await upgraded.version();
+  console.log("Contract version after upgrade:", contractVersion);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Adding a code example to the Hardhat ERC-721 code example to demonstrate how to use the UUPS proxy pattern to upgrade smart contracts.